### PR TITLE
Plugin config fix

### DIFF
--- a/catapult/preferences.py
+++ b/catapult/preferences.py
@@ -144,7 +144,7 @@ class TogglePlugin(PreferencesItem):
 
 class PreferencesDialog(Gtk.Dialog, catapult.DebugMixin, catapult.WindowMixin):
 
-    def __init__(self, window, plugins):
+    def __init__(self, window, plugins=()):
         GObject.GObject.__init__(self)
         self.items = []
         self.main_window = window

--- a/catapult/window.py
+++ b/catapult/window.py
@@ -281,7 +281,7 @@ class Window(Gtk.ApplicationWindow, catapult.DebugMixin, catapult.WindowMixin):
             self.update()
             dialog.destroy()
         self.hide()
-        dialog = catapult.PreferencesDialog(self)
+        dialog = catapult.PreferencesDialog(self, self._plugins)
         dialog.connect("response", on_response)
         dialog.run()
 


### PR DESCRIPTION
When using custom plugins, user-modified configuration is not saved in plugin's json file. It is caused by fact that instance of `PluginConfigurationStore` in plugin object and in each one of preference items are different objects. Therefore, when changing configuration in dialog and saving configuration from plugin, only default configuration is saved.

This PR fixes it by reusing plugins in preferences dialog instead of re-instantiating them each time dialog is executed.

his might be very ugly solution and I open for suggestions