### PR TITLE
Handle empty command lines - catapult will break if a distribution has desktop files with empty command-lines

### DIFF
--- a/catapult/plugins/apps.py
+++ b/catapult/plugins/apps.py
@@ -58,8 +58,6 @@ class AppsPlugin(Plugin):
 
     def _get_description(self, app):
         description = app.get_commandline()
-        if description is None:
-            return
         description = re.sub(r" %\w\b", "", description)
         description = re.sub(r" --$", "", description)
         return description.strip()
@@ -80,8 +78,8 @@ class AppsPlugin(Plugin):
     def _list_apps(self):
         key = lambda x: x.get_filename().lower()
         for app in sorted(Gio.AppInfo.get_all(), key=key):
-            if not self.conf.ignore_only_show_in:
-                if not app.should_show(): continue
+            if not self.conf.ignore_only_show_in and not app.should_show(): continue
+            if not app.get_commandline(): continue
             id = app.get_id()
             if id == "io.otsaloma.catapult.desktop": continue
             yield id, app

--- a/catapult/plugins/apps.py
+++ b/catapult/plugins/apps.py
@@ -58,6 +58,8 @@ class AppsPlugin(Plugin):
 
     def _get_description(self, app):
         description = app.get_commandline()
+        if description is None:
+            return
         description = re.sub(r" %\w\b", "", description)
         description = re.sub(r" --$", "", description)
         return description.strip()


### PR DESCRIPTION
Handle empty command lines - catapult will break if a distribution has desktop files with empty command-lines

Example:
```
08:49:12 DEBUG: AppsPlugin: 569 items in index
08:49:12 DEBUG: AppsPlugin: 569 items in index
08:49:16 DEBUG: AppsPlugin: Updating index...
08:49:16 DEBUG: AppsPlugin: 569 items in index
08:49:17 DEBUG: SearchManager: Starting search for 'q'
08:49:17 DEBUG: AppsPlugin: Found qemu.desktop for 'q'
08:49:17 ERROR: Failed to get search results from apps
Traceback (most recent call last):
  File "/tmp/catapult-devel.git/catapult/search.py", line 59, in _get_results
    for i, result in enumerate(plugin.search(query)):
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/catapult-devel.git/catapult/plugins/apps.py", line 99, in search
    description=self._get_description(app),
                ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/catapult-devel.git/catapult/plugins/apps.py", line 61, in _get_description
    description = re.sub(r" %\w\b", "", description)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/re/__init__.py", line 186, in sub
    return _compile(pattern, flags).sub(repl, string, count)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: expected string or bytes-like object, got 'NoneType'
08:49:17 DEBUG: SearchManager: builtins delivered in 0 ms
08:49:17 DEBUG: SearchManager: Found 0 results
08:49:17 DEBUG: SearchManager: Adjusted scores in 0 ms
```