### PR TITLE
Fix for new python-3.13

### DIFF
--- a/catapult/util.py
+++ b/catapult/util.py
@@ -20,7 +20,7 @@ import functools
 import inspect
 import os
 import re
-import urllib
+import urllib.parse
 
 from gi.repository import Gdk
 from gi.repository import Gtk


### PR DESCRIPTION
Fix for new python-3.13

After Archlinux updating python from  3.12.7-1 to 3.13.1-1 the following error prevented catapult from starting:

```
Traceback (most recent call last):
  File "/usr/local/share/catapult/catapult/app.py", line 40, in _on_activate
    window = catapult.Window()
  File "/usr/local/share/catapult/catapult/window.py", line 91, in __init__
    self.load_css()
    ~~~~~~~~~~~~~^^
  File "/usr/local/share/catapult/catapult/window.py", line 235, in load_css
    catapult.util.load_theme(catapult.conf.theme),
    ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/share/catapult/catapult/util.py", line 143, in load_theme
    uri = path_to_uri(path)
  File "/usr/local/share/catapult/catapult/util.py", line 160, in path_to_uri
    return "file://{}".format(urllib.parse.quote(path))
                              ^^^^^^^^^^^^
AttributeError: module 'urllib' has no attribute 'parse'
```
